### PR TITLE
update scalajs-dom to 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,6 @@ lazy val snake = project
   .settings(
     scalaVersion := "3.0.2",
     scalaJSUseMainModuleInitializer := true,
-    libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "1.2.0").cross(CrossVersion.for3Use2_13),
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.0.0",
     libraryDependencies += "org.scalameta" %%% "munit" % "0.7.29"
   ).enablePlugins(ScalaJSPlugin)


### PR DESCRIPTION
now we can avoid using the Scala 2 version of the library